### PR TITLE
Enhance tmux-dev command with repo-prefixed session naming

### DIFF
--- a/claude/commands/tmux-dev.md
+++ b/claude/commands/tmux-dev.md
@@ -7,32 +7,40 @@ Manage development servers running in tmux sessions. This workflow helps monitor
 To start a development server in a tmux session:
 
 ```
-Please start the development server in a new tmux session named [session-name]:
+Please start the development server in a new tmux session:
 - Navigate to the project directory
-- Create tmux session: tmux new-session -d -s [session-name] '[command]'
+- Get repo name: REPO=$(basename $(git rev-parse --show-toplevel))
+- Get branch name: BRANCH=$(git rev-parse --abbrev-ref HEAD)
+- Create tmux session: tmux new-session -d -s "$REPO-$BRANCH" '[command]'
 - Verify it's running with tmux list-sessions
 ```
 
-Example: "Start the Next.js dev server in tmux session 'my-app'"
+The session name will automatically use the repository name and current branch name.
+
+Example: "Start the Next.js dev server in tmux" (session will be named like 'my-app-feature/auth')
 
 ## Check Logs
 
 To view logs from a running tmux session without attaching:
 
 ```
-Show me the last [N] lines of logs from tmux session [session-name]:
-- Use: tmux capture-pane -t [session-name] -p | tail -[N]
+Show me the last [N] lines of logs from tmux session:
+- Get repo name: REPO=$(basename $(git rev-parse --show-toplevel))
+- Get branch name: BRANCH=$(git rev-parse --abbrev-ref HEAD)
+- Use: tmux capture-pane -t "$REPO-$BRANCH" -p | tail -[N]
 ```
 
-Example: "Show me the last 50 lines from the insta-admin tmux session"
+Example: "Show me the last 50 lines from the current project's tmux session"
 
 ## Monitor in Real-time
 
 To attach and monitor logs interactively:
 
 ```
-Attach me to the tmux session [session-name] to see real-time logs:
-- Use: tmux attach -t [session-name]
+Attach me to the tmux session to see real-time logs:
+- Get repo name: REPO=$(basename $(git rev-parse --show-toplevel))
+- Get branch name: BRANCH=$(git rev-parse --abbrev-ref HEAD)
+- Use: tmux attach -t "$REPO-$BRANCH"
 - Note: User can detach with Ctrl+B then D
 ```
 
@@ -50,17 +58,27 @@ Show me all running tmux sessions:
 To stop a development server:
 
 ```
-Stop the tmux session [session-name]:
-- Use: tmux kill-session -t [session-name]
+Stop the tmux session:
+- Get repo name: REPO=$(basename $(git rev-parse --show-toplevel))
+- Get branch name: BRANCH=$(git rev-parse --abbrev-ref HEAD)
+- Use: tmux kill-session -t "$REPO-$BRANCH"
 ```
 
 ## Common Patterns
 
 ### Quick Status Check
-"Is the insta-admin server still running? Show me the last 20 lines of logs"
+"Is the dev server for this project still running? Show me the last 20 lines of logs"
 
 ### Debugging
-"Show me the last 100 lines from the backend session, I think there's an error"
+"Show me the last 100 lines from this project's tmux session, I think there's an error"
 
-### Multiple Servers
-"Start frontend on port 3000 and backend on port 8000 in separate tmux sessions"
+### Multiple Projects
+"Start frontend on port 3000 and backend on port 8000 in separate tmux sessions named after their respective repos and branches"
+
+### Project-specific Development
+"Start the Next.js dev server in tmux" (automatically uses current repo and branch: my-app + feature/user-auth → session named 'my-app-feature/user-auth')
+
+### Multi-project Workflow
+- `dotfiles-main` (dotfiles repo on main branch)
+- `my-app-feature/auth` (my-app repo on feature/auth branch)
+- `api-server-bugfix/cors` (api-server repo on bugfix/cors branch)

--- a/claude/commands/tmux-dev.md
+++ b/claude/commands/tmux-dev.md
@@ -9,15 +9,15 @@ To start a development server in a tmux session:
 ```
 Please start the development server in a new tmux session:
 - Navigate to the project directory
-- Get repo name: REPO=$(basename $(git rev-parse --show-toplevel))
-- Get branch name: BRANCH=$(git rev-parse --abbrev-ref HEAD)
+- Get repo name: REPO=$(basename $(git rev-parse --show-toplevel 2>/dev/null) || echo "unknown")
+- Get branch name: BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | sed 's|/|_|g' || echo "detached")
 - Create tmux session: tmux new-session -d -s "$REPO-$BRANCH" '[command]'
 - Verify it's running with tmux list-sessions
 ```
 
 The session name will automatically use the repository name and current branch name.
 
-Example: "Start the Next.js dev server in tmux" (session will be named like 'my-app-feature/auth')
+Example: "Start the Next.js dev server in tmux" (session will be named like 'my-app-feature_auth')
 
 ## Check Logs
 
@@ -25,8 +25,8 @@ To view logs from a running tmux session without attaching:
 
 ```
 Show me the last [N] lines of logs from tmux session:
-- Get repo name: REPO=$(basename $(git rev-parse --show-toplevel))
-- Get branch name: BRANCH=$(git rev-parse --abbrev-ref HEAD)
+- Get repo name: REPO=$(basename $(git rev-parse --show-toplevel 2>/dev/null) || echo "unknown")
+- Get branch name: BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | sed 's|/|_|g' || echo "detached")
 - Use: tmux capture-pane -t "$REPO-$BRANCH" -p | tail -[N]
 ```
 
@@ -38,8 +38,8 @@ To attach and monitor logs interactively:
 
 ```
 Attach me to the tmux session to see real-time logs:
-- Get repo name: REPO=$(basename $(git rev-parse --show-toplevel))
-- Get branch name: BRANCH=$(git rev-parse --abbrev-ref HEAD)
+- Get repo name: REPO=$(basename $(git rev-parse --show-toplevel 2>/dev/null) || echo "unknown")
+- Get branch name: BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | sed 's|/|_|g' || echo "detached")
 - Use: tmux attach -t "$REPO-$BRANCH"
 - Note: User can detach with Ctrl+B then D
 ```
@@ -59,10 +59,17 @@ To stop a development server:
 
 ```
 Stop the tmux session:
-- Get repo name: REPO=$(basename $(git rev-parse --show-toplevel))
-- Get branch name: BRANCH=$(git rev-parse --abbrev-ref HEAD)
+- Get repo name: REPO=$(basename $(git rev-parse --show-toplevel 2>/dev/null) || echo "unknown")
+- Get branch name: BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | sed 's|/|_|g' || echo "detached")
 - Use: tmux kill-session -t "$REPO-$BRANCH"
 ```
+
+## Session Name Limitations
+
+**Note**: tmux session names have certain limitations:
+- Maximum length varies by system (typically 256 characters)
+- Special characters like `/` are replaced with `_` for compatibility
+- If not in a git repository, session names will use 'unknown-detached' as fallback
 
 ## Common Patterns
 
@@ -76,9 +83,9 @@ Stop the tmux session:
 "Start frontend on port 3000 and backend on port 8000 in separate tmux sessions named after their respective repos and branches"
 
 ### Project-specific Development
-"Start the Next.js dev server in tmux" (automatically uses current repo and branch: my-app + feature/user-auth → session named 'my-app-feature/user-auth')
+"Start the Next.js dev server in tmux" (automatically uses current repo and branch: my-app + feature/user-auth → session named 'my-app-feature_user-auth')
 
 ### Multi-project Workflow
 - `dotfiles-main` (dotfiles repo on main branch)
-- `my-app-feature/auth` (my-app repo on feature/auth branch)
-- `api-server-bugfix/cors` (api-server repo on bugfix/cors branch)
+- `my-app-feature_auth` (my-app repo on feature/auth branch)
+- `api-server-bugfix_cors` (api-server repo on bugfix/cors branch)


### PR DESCRIPTION
## Summary
- Enhanced tmux-dev command to use repository name prefix in session names
- Session names now follow pattern: `{repo-name}-{branch-name}` 
- Prevents conflicts when running multiple projects with same branch names
- Updated all operations (start, logs, monitor, stop) to use new naming scheme

## Test plan
- [ ] Test session creation with new naming pattern
- [ ] Verify session operations work across multiple projects
- [ ] Confirm no conflicts with same branch names in different repos
- [ ] Test examples in documentation work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)